### PR TITLE
adding a special case for format specifier with 64 bits integer

### DIFF
--- a/tunit.h
+++ b/tunit.h
@@ -74,7 +74,7 @@ Definitions of macros and constants
   }
 
 #define t_assert_int(a, op, b) t_assert_op(a, op, b, "%d")
-#define t_assert_int64(a, op, b) t_assert_op(a, op, b, "%ld") // Updated format specifier
+#define t_assert_int64(a, op, b) t_assert_op(a, op, b, "%ld")
 #define t_assert_char(a, op, b) t_assert_op(a, op, b, "%c")
 #define t_assert_false(a) t_assert_int(a, ==, 0)
 #define t_assert_double(a, op, b) t_assert_op(a, op, b, "%f")

--- a/tunit.h
+++ b/tunit.h
@@ -74,6 +74,7 @@ Definitions of macros and constants
   }
 
 #define t_assert_int(a, op, b) t_assert_op(a, op, b, "%d")
+#define t_assert_int64(a, op, b) t_assert_op(a, op, b, "%ld") // Updated format specifier
 #define t_assert_char(a, op, b) t_assert_op(a, op, b, "%c")
 #define t_assert_false(a) t_assert_int(a, ==, 0)
 #define t_assert_double(a, op, b) t_assert_op(a, op, b, "%f")


### PR DESCRIPTION
# changes
```c
#define t_assert_int64(a, op, b) t_assert_op(a, op, b, "%ld")
```
adding "%ld" to remove warning at compilation ex : 
```
tunit.h:49:15: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
   49 | #define C_RED "\033[0;31m"
      |               ^~~~~~~~~~~~
tunit.h:54:11: note: in expansion of macro ‘C_RED’
   54 |           C_RED "FAIL> %s(%s):%d - assertion failed " fmt " %s " fmt "" C_NORM \
      |           ^~~~~
tunit.h:60:5: note: in expansion of macro ‘t_errf’
   60 |     t_errf(a, op, b, fmt);                                                     \
      |     ^~~~~~
tunit.h:76:32: note: in expansion of macro ‘t_assert_op’
   76 | #define t_assert_int(a, op, b) t_assert_op(a, op, b, "%d")
      |                                ^~~~~~~~~~~
main.c:11:5: note: in expansion of macro ‘t_assert_int’
   11 |     t_assert_int(a, == , b)
      |     ^~~~~~~~~~~~
tunit.h:49:15: warning: format ‘%d’ expects argument of type ‘int’, but argument 8 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
   49 | #define C_RED "\033[0;31m"
      |               ^~~~~~~~~~~~
tunit.h:54:11: note: in expansion of macro ‘C_RED’
   54 |           C_RED "FAIL> %s(%s):%d - assertion failed " fmt " %s " fmt "" C_NORM \
      |           ^~~~~
tunit.h:60:5: note: in expansion of macro ‘t_errf’
   60 |     t_errf(a, op, b, fmt);                                                     \
      |     ^~~~~~
tunit.h:76:32: note: in expansion of macro ‘t_assert_op’
   76 | #define t_assert_int(a, op, b) t_assert_op(a, op, b, "%d")
      |                                ^~~~~~~~~~~
main.c:11:5: note: in expansion of macro ‘t_assert_int’
   11 |     t_assert_int(a, == , b)
      |     ^~~~~~~~~~~~
```

# limitations

On 32 bits architecture (raspy) , the format specifier for 64 bits becomes "%lld" and 32 bits come "%ld" this case is not taken into account for this pr as the header is not meant to be used on 32 bits architecture, however if it was to be added, a boolean could be used to set the architecture in `t_runSuites` or sooner to allow or not to use "%lld" or "%ld"