### PR TITLE
adding assert on (void*) to allow for (void*)-1

### DIFF
--- a/tunit.h
+++ b/tunit.h
@@ -25,7 +25,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #ifndef TUNIT_H
-#define TUNIT_H 0
+#define TUNIT_H 42
 typedef struct TestSuite testsuite_t;
 typedef struct Test test_t;
 /*

--- a/tunit.h
+++ b/tunit.h
@@ -75,11 +75,12 @@ Definitions of macros and constants
 
 #define t_assert_int(a, op, b) t_assert_op(a, op, b, "%d")
 #define t_assert_long_int(a, op, b) t_assert_op(a, op, b, "%ld")
+#define t_assert_long_long_int(a, op, b) t_assert_op(a, op, b, "%lld")
 #define t_assert_char(a, op, b) t_assert_op(a, op, b, "%c")
 #define t_assert_false(a) t_assert_int(a, ==, 0)
 #define t_assert_double(a, op, b) t_assert_op(a, op, b, "%f")
 #define t_assert_float(a, op, b) t_assert_op(a, op, b, "%f")
-#define t_assert_void(a, op, b) t_assert_op(a, op, b, "%p")
+#define t_assert_void(a, op, b) t_assert_op((void*) a, op, (void*) b, "%p")
 #define t_assert_true(a) t_assert_int(a, ==, 1)
 
 #endif

--- a/tunit.h
+++ b/tunit.h
@@ -25,7 +25,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #ifndef TUNIT_H
-#define TUNIT_H 42
+#define TUNIT_H 0
 typedef struct TestSuite testsuite_t;
 typedef struct Test test_t;
 /*
@@ -74,12 +74,14 @@ Definitions of macros and constants
   }
 
 #define t_assert_int(a, op, b) t_assert_op(a, op, b, "%d")
-#define t_assert_int64(a, op, b) t_assert_op(a, op, b, "%ld")
+#define t_assert_long_int(a, op, b) t_assert_op(a, op, b, "%ld")
 #define t_assert_char(a, op, b) t_assert_op(a, op, b, "%c")
 #define t_assert_false(a) t_assert_int(a, ==, 0)
 #define t_assert_double(a, op, b) t_assert_op(a, op, b, "%f")
 #define t_assert_float(a, op, b) t_assert_op(a, op, b, "%f")
+#define t_assert_void(a, op, b) t_assert_op(a, op, b, "%p")
 #define t_assert_true(a) t_assert_int(a, ==, 1)
+
 #endif
 // TODO: Remove this define. Currently useful for IDE.
 #define TUNIT_IMPLEMENTATION


### PR DESCRIPTION
adds assert_void,
defines TUNIT_IMPLEMENTATION TO 0 (less random number) could also be defined to nothing
and changes int64 to long int, since for 32bits system int64 is long long int